### PR TITLE
Pipeline profile improvements for GitLab

### DIFF
--- a/Policy/ModuleSearch.policy.yml
+++ b/Policy/ModuleSearch.policy.yml
@@ -1,0 +1,29 @@
+title: "Search for modules"
+name: Drupal:ModuleScan
+class: \Drutiny\GovCMS\Audit\ModuleSearch
+tags:
+  - Compliance
+description: |
+  Scan a specified directory or the default theme path for additional themes or modules.
+remediation: |
+  Additonal themes will not fail - remove any modules contained in the directory.
+success: |
+  No modules were found in the specified directory.
+
+  The following themes were found:
+  {{#themesFound}}
+    - {{ . }}
+  {{/themesFound}}
+failure: |
+  The following modules were found in the specified directory:
+
+  {{#modulesFound}}
+    - {{ . }}
+  {{/modulesFound}}
+parameters:
+  directory:
+    type: string
+    default: ""
+    description: |
+      Path to the directory to scan for nested modules and themes.
+      Leave as default ("") to dynamically detect the default theme path.

--- a/Profiles/d7-gitlab.profile.yml
+++ b/Profiles/d7-gitlab.profile.yml
@@ -1,0 +1,46 @@
+title: 'Drupal 7 Gitlab Pipeline'
+format:
+  html:
+    template: govcms-page
+policies:
+  Drupal:LintTheme:
+    severity: low
+  Drupal:ThemeSecurity:
+    severity: critical
+    parameters:
+      filetypes:
+        - php
+        - inc
+        - theme
+      patterns:
+        - "_POST"
+        - "exec\\("
+        - "db_query"
+        - "db_select"
+        - "db_merge"
+        - "db_update"
+        - "db_write_record"
+        - "\\->query"
+        - "drupal_http_request"
+        - "curl_init"
+        - "passthru"
+        - "proc_open"
+        - "system\\("
+        - "sleep\\("
+        - "mysql_"
+        - "mysqli"
+        - "sqlite"
+        - "db_query"
+        - "db_fetch"
+        - "db_result"
+        - "pager_query"
+        - "db_set_active"
+        - "db_select"
+        - "db_insert"
+        - "db_update"
+        - "db_delete"
+        - "fetchAll"
+        - "fetchField"
+        - "fetchObject"
+        - "fetchAssoc"
+        - "countQuery"

--- a/Profiles/gitlab.profile.yml
+++ b/Profiles/gitlab.profile.yml
@@ -1,4 +1,4 @@
-title: 'Drupal 7 Gitlab Pipeline'
+title: 'Drupal Gitlab Pipeline'
 format:
   html:
     template: govcms-page

--- a/Profiles/gitlab.profile.yml
+++ b/Profiles/gitlab.profile.yml
@@ -5,6 +5,8 @@ format:
 policies:
   Drupal:LintTheme:
     severity: low
+  Drupal:ModuleScan:
+    severity: critical
   Drupal:ThemeSecurity:
     severity: critical
     parameters:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^7.1.0",
-    "drutiny/drutiny": "2.3.x-dev#b759dc6",
+    "drutiny/drutiny": "2.3.x-dev#92719de",
     "drutiny/http": "2.4",
     "drutiny/plugin-drupal-7": "2.1",
     "drutiny/plugin-drupal-8": "2.1"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^7.1.0",
-    "drutiny/drutiny": "2.3.x-dev#92719de",
+    "drutiny/drutiny": "2.3.x-dev#b759dc6",
     "drutiny/http": "2.4",
     "drutiny/plugin-drupal-7": "2.1",
     "drutiny/plugin-drupal-8": "2.1"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^7.1.0",
-    "drutiny/drutiny": "2.3.1",
+    "drutiny/drutiny": "2.3.x-dev#92719de",
     "drutiny/http": "2.4",
     "drutiny/plugin-drupal-7": "2.1",
     "drutiny/plugin-drupal-8": "2.1"

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
   ],
   "require": {
     "php": "^7.1.0",
-    "drutiny/drutiny": "2.3.1",
-    "drutiny/http": "2.4",
-    "drutiny/plugin-drupal-7": "2.1",
-    "drutiny/plugin-drupal-8": "2.1"
+    "drutiny/drutiny": "2.3.3",
+    "drutiny/http": "2.5",
+    "drutiny/plugin-drupal-7": "2.2",
+    "drutiny/plugin-drupal-8": "2.2"
   },
   "autoload": {
       "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^7.1.0",
-    "drutiny/drutiny": "2.3.x-dev#92719de",
+    "drutiny/drutiny": "2.3.1",
     "drutiny/http": "2.4",
     "drutiny/plugin-drupal-7": "2.1",
     "drutiny/plugin-drupal-8": "2.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7e7775c7829b6ce9c8b0698a0539eb3",
+    "content-hash": "215d0603865392fa162ee14a44323bf2",
     "packages": [
         {
             "name": "caseyamcl/toc",
@@ -308,24 +308,25 @@
         },
         {
             "name": "drutiny/drutiny",
-            "version": "2.3.1",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drutiny/drutiny.git",
-                "reference": "3c822c4f72a90614593478c2d71b4ceba35641ed"
+                "reference": "b48e52d20a4d8e2704ac2e509bdb935b764655f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drutiny/drutiny/zipball/3c822c4f72a90614593478c2d71b4ceba35641ed",
-                "reference": "3c822c4f72a90614593478c2d71b4ceba35641ed",
+                "url": "https://api.github.com/repos/drutiny/drutiny/zipball/b48e52d20a4d8e2704ac2e509bdb935b764655f0",
+                "reference": "b48e52d20a4d8e2704ac2e509bdb935b764655f0",
                 "shasum": ""
             },
             "require": {
                 "caseyamcl/toc": "~1.0",
                 "composer/semver": "^1.4.2",
                 "doctrine/annotations": "^v1.2",
-                "drutiny/http": "^2.4",
+                "drutiny/http": "^2.5",
                 "erusev/parsedown": "^1.6.3",
+                "ext-bcmath": "*",
                 "fiasco/symfony-console-style-markdown": "~1.0",
                 "mustache/mustache": "^2.11",
                 "paragonie/random_compat": "^2.0",
@@ -378,20 +379,20 @@
                 "report",
                 "ssh"
             ],
-            "time": "2018-08-29T20:49:49+00:00"
+            "time": "2019-03-13T03:40:07+00:00"
         },
         {
             "name": "drutiny/http",
-            "version": "2.4",
+            "version": "2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drutiny/http.git",
-                "reference": "c02baa62ba5c0ef9dda2722b2e6a55b559baf60e"
+                "reference": "4373c82eb454828791af538af6ae2474698f9d0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drutiny/http/zipball/c02baa62ba5c0ef9dda2722b2e6a55b559baf60e",
-                "reference": "c02baa62ba5c0ef9dda2722b2e6a55b559baf60e",
+                "url": "https://api.github.com/repos/drutiny/http/zipball/4373c82eb454828791af538af6ae2474698f9d0c",
+                "reference": "4373c82eb454828791af538af6ae2474698f9d0c",
                 "shasum": ""
             },
             "require": {
@@ -408,20 +409,20 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Drutiny auditing and policies on HTTP requests",
-            "time": "2018-08-16T22:13:43+00:00"
+            "time": "2019-03-11T10:45:52+00:00"
         },
         {
             "name": "drutiny/plugin-drupal-7",
-            "version": "2.1",
+            "version": "2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drutiny/plugin-drupal-7.git",
-                "reference": "c6393c73b8eb69b8ad88ac06024e3b8cf3668644"
+                "reference": "fadb6de28c49e5caba4970290796fba4b655b87d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drutiny/plugin-drupal-7/zipball/c6393c73b8eb69b8ad88ac06024e3b8cf3668644",
-                "reference": "c6393c73b8eb69b8ad88ac06024e3b8cf3668644",
+                "url": "https://api.github.com/repos/drutiny/plugin-drupal-7/zipball/fadb6de28c49e5caba4970290796fba4b655b87d",
+                "reference": "fadb6de28c49e5caba4970290796fba4b655b87d",
                 "shasum": ""
             },
             "require": {
@@ -462,20 +463,20 @@
                 "report",
                 "ssh"
             ],
-            "time": "2018-07-29T21:25:44+00:00"
+            "time": "2019-01-07T02:29:50+00:00"
         },
         {
             "name": "drutiny/plugin-drupal-8",
-            "version": "2.1",
+            "version": "2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drutiny/plugin-drupal-8.git",
-                "reference": "0319b2f30657d9d6eeb77916ba146209f4044edb"
+                "reference": "58ba0522b3ccae4f9b81b4946cc7fc4d944c9860"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drutiny/plugin-drupal-8/zipball/0319b2f30657d9d6eeb77916ba146209f4044edb",
-                "reference": "0319b2f30657d9d6eeb77916ba146209f4044edb",
+                "url": "https://api.github.com/repos/drutiny/plugin-drupal-8/zipball/58ba0522b3ccae4f9b81b4946cc7fc4d944c9860",
+                "reference": "58ba0522b3ccae4f9b81b4946cc7fc4d944c9860",
                 "shasum": ""
             },
             "require": {
@@ -516,20 +517,20 @@
                 "report",
                 "ssh"
             ],
-            "time": "2018-08-09T23:02:35+00:00"
+            "time": "2019-01-07T02:30:14+00:00"
         },
         {
             "name": "erusev/parsedown",
-            "version": "1.7.1",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/erusev/parsedown.git",
-                "reference": "92e9c27ba0e74b8b028b111d1b6f956a15c01fc1"
+                "reference": "d60bcdc46978357759ecb13cb4b078da783f8faf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/92e9c27ba0e74b8b028b111d1b6f956a15c01fc1",
-                "reference": "92e9c27ba0e74b8b028b111d1b6f956a15c01fc1",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/d60bcdc46978357759ecb13cb4b078da783f8faf",
+                "reference": "d60bcdc46978357759ecb13cb4b078da783f8faf",
                 "shasum": ""
             },
             "require": {
@@ -562,7 +563,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2018-03-08T01:11:30+00:00"
+            "time": "2019-03-17T17:19:46+00:00"
         },
         {
             "name": "fiasco/symfony-console-style-markdown",
@@ -718,32 +719,33 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.4.2",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+                "reference": "9f83dded91781a01c63574e387eaa769be769115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
+                "reference": "9f83dded91781a01c63574e387eaa769be769115",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -773,13 +775,14 @@
             "keywords": [
                 "http",
                 "message",
+                "psr-7",
                 "request",
                 "response",
                 "stream",
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20T17:10:46+00:00"
+            "time": "2018-12-04T20:46:45+00:00"
         },
         {
             "name": "kevinrob/guzzle-cache-middleware",
@@ -924,31 +927,33 @@
         },
         {
             "name": "masterminds/html5",
-            "version": "2.3.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "2c37c6c520b995b761674de3be8455a381679067"
+                "reference": "c961ca6a0a81dc6b55b6859b3f9ea7f402edf9ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/2c37c6c520b995b761674de3be8455a381679067",
-                "reference": "2c37c6c520b995b761674de3be8455a381679067",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/c961ca6a0a81dc6b55b6859b3f9ea7f402edf9ad",
+                "reference": "c961ca6a0a81dc6b55b6859b3f9ea7f402edf9ad",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
                 "ext-libxml": "*",
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*",
+                "phpunit/phpunit": "^4.8.35",
                 "sami/sami": "~2.0",
                 "satooshi/php-coveralls": "1.0.*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -985,7 +990,7 @@
                 "serializer",
                 "xml"
             ],
-            "time": "2017-09-04T12:26:28+00:00"
+            "time": "2019-03-10T11:41:28+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -1035,16 +1040,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.17",
+            "version": "v2.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d"
+                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/29af24f25bab834fcbb38ad2a69fa93b867e070d",
-                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
+                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
                 "shasum": ""
             },
             "require": {
@@ -1080,7 +1085,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-07-04T16:31:37+00:00"
+            "time": "2019-01-03T20:59:08+00:00"
         },
         {
             "name": "psr/cache",
@@ -1180,16 +1185,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -1223,7 +1228,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -1274,6 +1279,46 @@
             "time": "2017-10-23T01:57:42+00:00"
         },
         {
+            "name": "ralouphie/getallheaders",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.0",
+                "satooshi/php-coveralls": ">=1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2016-02-11T07:05:27+00:00"
+        },
+        {
             "name": "romaricdrigon/metayaml",
             "version": "1.1",
             "source": {
@@ -1317,16 +1362,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v3.4.17",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "4f29972d3fae5febec5c18db70e7dd2957e74ad6"
+                "reference": "aa02b67f961a15cef21f21d293afcac574a62118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/4f29972d3fae5febec5c18db70e7dd2957e74ad6",
-                "reference": "4f29972d3fae5febec5c18db70e7dd2957e74ad6",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/aa02b67f961a15cef21f21d293afcac574a62118",
+                "reference": "aa02b67f961a15cef21f21d293afcac574a62118",
                 "shasum": ""
             },
             "require": {
@@ -1383,20 +1428,20 @@
                 "caching",
                 "psr6"
             ],
-            "time": "2018-09-25T07:13:51+00:00"
+            "time": "2019-02-23T15:06:07+00:00"
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.4.17",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
-                "reference": "f31333bdff54c7595f834d510a6d2325573ddb36"
+                "reference": "4459eef5298dedfb69f771186a580062b8516497"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/f31333bdff54c7595f834d510a6d2325573ddb36",
-                "reference": "f31333bdff54c7595f834d510a6d2325573ddb36",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/4459eef5298dedfb69f771186a580062b8516497",
+                "reference": "4459eef5298dedfb69f771186a580062b8516497",
                 "shasum": ""
             },
             "require": {
@@ -1439,20 +1484,20 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T12:28:39+00:00"
+            "time": "2019-01-16T09:39:14+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.17",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b"
+                "reference": "71ce77f37af0c5ffb9590e43cc4f70e426945c5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
-                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
+                "url": "https://api.github.com/repos/symfony/console/zipball/71ce77f37af0c5ffb9590e43cc4f70e426945c5e",
+                "reference": "71ce77f37af0c5ffb9590e43cc4f70e426945c5e",
                 "shasum": ""
             },
             "require": {
@@ -1464,6 +1509,9 @@
                 "symfony/dependency-injection": "<3.4",
                 "symfony/process": "<3.3"
             },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~3.3|~4.0",
@@ -1473,7 +1521,7 @@
                 "symfony/process": "~3.3|~4.0"
             },
             "suggest": {
-                "psr/log-implementation": "For using the console logger",
+                "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -1508,20 +1556,88 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:33:53+00:00"
+            "time": "2019-02-23T15:06:07+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v4.1.6",
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "e3f76ce6198f81994e019bb2b4e533e9de1b9b90"
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e3f76ce6198f81994e019bb2b4e533e9de1b9b90",
-                "reference": "e3f76ce6198f81994e019bb2b4e533e9de1b9b90",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v4.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "de73f48977b8eaf7ce22814d66e43a1662cc864f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/de73f48977b8eaf7ce22814d66e43a1662cc864f",
+                "reference": "de73f48977b8eaf7ce22814d66e43a1662cc864f",
                 "shasum": ""
             },
             "require": {
@@ -1537,7 +1653,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1564,20 +1680,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:36:10+00:00"
+            "time": "2019-03-03T18:11:24+00:00"
         },
         {
             "name": "symfony/expression-language",
-            "version": "v3.4.17",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/expression-language.git",
-                "reference": "d60e37ab9838338d959f2cc177a66cf498293788"
+                "reference": "74631d47774cfa59bfb4a0de18cdf700fb98d658"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/expression-language/zipball/d60e37ab9838338d959f2cc177a66cf498293788",
-                "reference": "d60e37ab9838338d959f2cc177a66cf498293788",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/74631d47774cfa59bfb4a0de18cdf700fb98d658",
+                "reference": "74631d47774cfa59bfb4a0de18cdf700fb98d658",
                 "shasum": ""
             },
             "require": {
@@ -1614,20 +1730,20 @@
             ],
             "description": "Symfony ExpressionLanguage Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T09:06:28+00:00"
+            "time": "2019-01-16T12:52:19+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.17",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "54ba444dddc5bd5708a34bd095ea67c6eb54644d"
+                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/54ba444dddc5bd5708a34bd095ea67c6eb54644d",
-                "reference": "54ba444dddc5bd5708a34bd095ea67c6eb54644d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/fcdde4aa38f48190ce70d782c166f23930084f9b",
+                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b",
                 "shasum": ""
             },
             "require": {
@@ -1663,11 +1779,11 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-03T08:46:40+00:00"
+            "time": "2019-02-22T14:44:53+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-apcu.git",
@@ -1723,7 +1839,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -1766,7 +1882,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1781,16 +1897,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
                 "shasum": ""
             },
             "require": {
@@ -1836,20 +1952,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.17",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "1dc2977afa7d70f90f3fefbcd84152813558910e"
+                "reference": "009f8dda80930e89e8344a4e310b08f9ff07dd2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/1dc2977afa7d70f90f3fefbcd84152813558910e",
-                "reference": "1dc2977afa7d70f90f3fefbcd84152813558910e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/009f8dda80930e89e8344a4e310b08f9ff07dd2e",
+                "reference": "009f8dda80930e89e8344a4e310b08f9ff07dd2e",
                 "shasum": ""
             },
             "require": {
@@ -1885,30 +2001,34 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T12:28:39+00:00"
+            "time": "2019-01-16T13:27:11+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v4.1.6",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "9f0b61e339160a466ebcde167a6c5521c810e304"
+                "reference": "748464177a77011f8f4cdd076773862ce4915f8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/9f0b61e339160a466ebcde167a6c5521c810e304",
-                "reference": "9f0b61e339160a466ebcde167a6c5521c810e304",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/748464177a77011f8f4cdd076773862ce4915f8f",
+                "reference": "748464177a77011f8f4cdd076773862ce4915f8f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
+                "symfony/contracts": "^1.0.2",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/config": "<3.4",
                 "symfony/dependency-injection": "<3.4",
                 "symfony/yaml": "<3.4"
+            },
+            "provide": {
+                "symfony/translation-contracts-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -1927,7 +2047,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1954,20 +2074,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:36:10+00:00"
+            "time": "2019-02-27T03:31:50+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v3.4.17",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "9f8dbf0dceb03815c3160a279bf8cf4f8018a1c5"
+                "reference": "21f8a7da6d4d8e6e34bd4e2bfaa24fa373886907"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/9f8dbf0dceb03815c3160a279bf8cf4f8018a1c5",
-                "reference": "9f8dbf0dceb03815c3160a279bf8cf4f8018a1c5",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/21f8a7da6d4d8e6e34bd4e2bfaa24fa373886907",
+                "reference": "21f8a7da6d4d8e6e34bd4e2bfaa24fa373886907",
                 "shasum": ""
             },
             "require": {
@@ -2039,20 +2159,20 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:33:53+00:00"
+            "time": "2019-02-25T09:32:21+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.17",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f"
+                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/640b6c27fed4066d64b64d5903a86043f4a4de7f",
-                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/57f1ce82c997f5a8701b89ef970e36bb657fd09c",
+                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c",
                 "shasum": ""
             },
             "require": {
@@ -2098,35 +2218,35 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:33:53+00:00"
+            "time": "2019-02-23T15:06:07+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v1.35.4",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "7e081e98378a1e78c29cc9eba4aefa5d78a05d2a"
+                "reference": "874adbd9222f928f6998732b25b01b41dff15b0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/7e081e98378a1e78c29cc9eba4aefa5d78a05d2a",
-                "reference": "7e081e98378a1e78c29cc9eba4aefa5d78a05d2a",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/874adbd9222f928f6998732b25b01b41dff15b0c",
+                "reference": "874adbd9222f928f6998732b25b01b41dff15b0c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": ">=5.4.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "psr/container": "^1.0",
                 "symfony/debug": "^2.7",
-                "symfony/phpunit-bridge": "^3.3"
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.35-dev"
+                    "dev-master": "1.38-dev"
                 }
             },
             "autoload": {
@@ -2164,7 +2284,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2018-07-13T07:12:17+00:00"
+            "time": "2019-03-12T18:45:24+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7e7775c7829b6ce9c8b0698a0539eb3",
+    "content-hash": "46a218415abd1082e301be2d558fd9c5",
     "packages": [
         {
             "name": "caseyamcl/toc",
@@ -308,16 +308,16 @@
         },
         {
             "name": "drutiny/drutiny",
-            "version": "2.3.1",
+            "version": "2.3.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drutiny/drutiny.git",
-                "reference": "3c822c4f72a90614593478c2d71b4ceba35641ed"
+                "reference": "92719de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drutiny/drutiny/zipball/3c822c4f72a90614593478c2d71b4ceba35641ed",
-                "reference": "3c822c4f72a90614593478c2d71b4ceba35641ed",
+                "url": "https://api.github.com/repos/drutiny/drutiny/zipball/92719de",
+                "reference": "92719de",
                 "shasum": ""
             },
             "require": {
@@ -326,6 +326,7 @@
                 "doctrine/annotations": "^v1.2",
                 "drutiny/http": "^2.4",
                 "erusev/parsedown": "^1.6.3",
+                "ext-bcmath": "*",
                 "fiasco/symfony-console-style-markdown": "~1.0",
                 "mustache/mustache": "^2.11",
                 "paragonie/random_compat": "^2.0",
@@ -378,7 +379,7 @@
                 "report",
                 "ssh"
             ],
-            "time": "2018-08-29T20:49:49+00:00"
+            "time": "2019-01-23T02:50:23+00:00"
         },
         {
             "name": "drutiny/http",
@@ -2170,7 +2171,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "drutiny/drutiny": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "46a218415abd1082e301be2d558fd9c5",
+    "content-hash": "d7e7775c7829b6ce9c8b0698a0539eb3",
     "packages": [
         {
             "name": "caseyamcl/toc",
@@ -308,16 +308,16 @@
         },
         {
             "name": "drutiny/drutiny",
-            "version": "2.3.x-dev",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drutiny/drutiny.git",
-                "reference": "92719de"
+                "reference": "3c822c4f72a90614593478c2d71b4ceba35641ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drutiny/drutiny/zipball/92719de",
-                "reference": "92719de",
+                "url": "https://api.github.com/repos/drutiny/drutiny/zipball/3c822c4f72a90614593478c2d71b4ceba35641ed",
+                "reference": "3c822c4f72a90614593478c2d71b4ceba35641ed",
                 "shasum": ""
             },
             "require": {
@@ -326,7 +326,6 @@
                 "doctrine/annotations": "^v1.2",
                 "drutiny/http": "^2.4",
                 "erusev/parsedown": "^1.6.3",
-                "ext-bcmath": "*",
                 "fiasco/symfony-console-style-markdown": "~1.0",
                 "mustache/mustache": "^2.11",
                 "paragonie/random_compat": "^2.0",
@@ -379,7 +378,7 @@
                 "report",
                 "ssh"
             ],
-            "time": "2019-01-23T02:50:23+00:00"
+            "time": "2018-08-29T20:49:49+00:00"
         },
         {
             "name": "drutiny/http",
@@ -2171,9 +2170,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "drutiny/drutiny": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/src/Audit/ModuleSearch.php
+++ b/src/Audit/ModuleSearch.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drutiny\GovCMS\Audit;
+
+use Drutiny\Audit;
+use Drutiny\Sandbox\Sandbox;
+use Drutiny\Annotation\Param;
+
+/**
+ * Scan for modules and themes inside the default theme folder (or a specified directory).
+ * @Param(
+ *  name = "directory",
+ *  description = "Absolute filepath to directory to scan",
+ *  type = "string",
+ *  default = ""
+ * )
+ */
+class ModuleSearch extends Audit {
+
+  /**
+   * @inheritdoc
+   */
+  public function audit(Sandbox $sandbox) {
+
+    $info = $sandbox->drush(['format' => 'json'])->status();
+    $themeName = $info['theme'];
+    $rootPath = $info['root'];
+    $themePath = $sandbox->drush()->eval("'return drupal_get_path('theme', '{$themeName}');'");
+    $results = array();
+    $modulesFound = array();
+    $themesFound = array();
+
+    $directory = $sandbox->getParameter('directory', "");
+    if ($directory === '') {
+      $directory = "$rootPath/$themePath";
+    }
+
+    $types = array('info', 'module', 'theme', 'info.yml');
+    $command = ['find', $directory, '-type f'];
+
+    $conditions = [];
+    foreach ($types as $type) {
+      $conditions[] = '-iname "*.' . $type . '"';
+    }
+
+    $command[] = '\( ' . implode(' -or ', $conditions) . ' \)';
+    $command[] = " || exit 0";
+
+    $command = '\'' . implode(' ', $command) . '\'';
+    $sandbox->logger()->info('[' . __CLASS__ . '] ' . $command);
+    $output = $sandbox->drush()->ssh($command);
+
+    if (empty($output)) {
+      return Audit::NOT_APPLICABLE;
+    }
+
+    $matches = array_filter(explode(PHP_EOL, $output));
+    $matches = array_map(function ($line) {
+      list($filepath, $line_number, $code) = explode(':', $line, 3);
+      return [
+        'file' => basename($filepath),
+        'directory' => implode('/', array_slice(explode('/', $filepath), 0, -1)),
+        'machine_name' => implode('.', array_slice(explode('.', basename($filepath)), 0, 1)),
+
+      ];
+    }, $matches);
+
+    if ($result = $sandbox->drush(['format' => 'json', 'fields' => 'type'])->pmList()) {
+      foreach ($matches[0] as $module) {
+        if ($result[$module]['type'] === 'module') {
+          $modulesFound[] = $module;
+        }
+        if ($result[$module]['type'] === 'theme') {
+          $themesFound[] = $module;
+        }
+      }
+    }
+    else {
+      return Audit::ERROR;
+    }
+
+    $sandbox->setParameter('themesFound', $themesFound);
+    $sandbox->setParameter('modulesFound', $modulesFound);
+
+    return empty($modulesFound);
+  }
+
+}


### PR DESCRIPTION
This PR introduces changes merged upstream which allows Drutiny to exit with exit codes resembling the code of the severity rating. In this case a failing pipeline would exit with exit code `8`.

This is just stage one as testing will need to happen, and we will need to review the policy described below.

**Changes**
* Updates Drutiny
* Includes a draft profile with two audits - one low priority one and one critical audit which can fail a pipeline as needed.