### PR TITLE
#36: Image optimisation audit

### DIFF
--- a/Policy/largeDrupalFilesOfTypes.policy.yml
+++ b/Policy/largeDrupalFilesOfTypes.policy.yml
@@ -1,0 +1,45 @@
+title: Large Drupal Files matching type
+class: \Drutiny\GovCMS\Audit\Drupal\LargeDrupalFilesOfTypes
+name: Drupal:largeFilesOfTypes
+tags:
+  - Drupal 8
+  - Drupal 7
+  - Health Analysis
+description: |
+  Large static assets should be optimized for online display or ideally be housed in other services, e.g.
+  Amazon S3 (for files) or Youtube (for videos). Storing large files can consume storage volumes,
+  increase page load time and contribute to a higher than desired cache eviction rate. Varnish, on Acquia Cloud,
+  does not cache files larger than 10 MB.
+
+  This extends on the LargeDrupalFiles policy/audit provided by Drutiny and adds an extension check when the
+  extensions parameter is provided.
+
+  This policy identifies files managed by Drupal that are larger than {{readable_max_size}}.
+remediation: |
+  Either delete the large Drupal files found that exceed {{readable_max_size}} if they are not needed, compress or optimize them,
+  or look to house them in a more appropriate location.
+success: No large files found with matching extensions.
+failure: |
+  **{{total}} Large Drupal file{{plural}} found matching input extensions**<br>
+  The table below contains the following data:
+      - **URI** - The path and filename.
+      - **Size** - The size of the file as reported by Drupal.
+      - **Used** - Determines if the file is associated with any content according to Drupal's file_usage table.
+
+  URI | Size | Used
+    --- | --- | ---
+    {{# files }}
+      {{uri}} | {{size}} | {{usage}}
+    {{/ files }}
+    {{too_many_files}}
+parameters:
+  max_size:
+    default: 2000000
+  extensions:
+    default:
+      - bmp
+      - gif
+      - png
+      - tiff
+      - jpg
+      - jpeg

--- a/Policy/largeDrupalFilesOfTypes.policy.yml
+++ b/Policy/largeDrupalFilesOfTypes.policy.yml
@@ -19,8 +19,12 @@ remediation: |
   Either delete the large Drupal files found that exceed {{readable_max_size}} if they are not needed, compress or optimize them,
   or look to house them in a more appropriate location.
 success: No large files found with matching extensions.
-failure: |
-  **{{total}} Large Drupal file{{plural}} found matching input extensions**<br>
+warning: |
+  Files with configured extensions were found over {{readable_max_size}}.
+
+  Work towards reducing the size of all {{total}} files to remediate this warning.
+  The results otherwise poses no risk other than site performance and/or cachability.
+
   The table below contains the following data:
       - **URI** - The path and filename.
       - **Size** - The size of the file as reported by Drupal.

--- a/Profiles/d7-full.profile.yml
+++ b/Profiles/d7-full.profile.yml
@@ -140,6 +140,8 @@ policies:
     severity: normal
     parameters:
       max_size : 20000000 #20MB
+  Drupal:largeFilesOfTypes:
+    severity: normal
   fs:SensitivePublicFiles:
     severity: normal
     parameters:

--- a/Profiles/d8-full.profile.yml
+++ b/Profiles/d8-full.profile.yml
@@ -61,6 +61,8 @@ policies:
     severity: normal
     parameters:
       extensions: 'sql,php,sh,py,bz2,gz,tar,tgz,zip'
+  Drupal:largeFilesOfTypes:
+    severity: normal
 
   # Theme specific checks.
   Drupal:LintTheme:

--- a/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
+++ b/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drutiny\GovCMS\Audit\Drupal;
+
+use Drutiny\Audit;
+use Drutiny\Sandbox\Sandbox;
+use Drutiny\AuditResponse\AuditResponse;
+use Drutiny\Annotation\Param;
+use Drutiny\Annotation\Token;
+
+/**
+ * Identify files with a specified extensions which are larger than a specfied size. Pass if no matching files found.
+ * @Param(
+ *  name = "max_size",
+ *  description = "Report files larger than this value measured in bytes.",
+ *  type = "integer",
+ *  default = 10000000
+ * )
+ * @Param(
+ *  name = "extensions",
+ *  description = "File extensions to include.",
+ *  type = "array"
+ * )
+ * @Token(
+ *  name = "total",
+ *  description = "Total number of large files found",
+ *  type = "integer"
+ * )
+ * @Token(
+ *  name = "too_many_files",
+ *  description = "Text to display if there are more than 10 files found.",
+ *  type = "integer"
+ * )
+ * @Token(
+ *  name = "files",
+ *  description = "A list of up to 10 files that are too large.",
+ *  type = "integer"
+ * )
+ * @Token(
+ *  name = "plural",
+ *  description = "This variable will contain an 's' if there is more than one issue found.",
+ *  type = "string",
+ *  default = ""
+ * )
+ */
+class LargeDrupalFilesOfTypes extends Audit {
+
+  /**
+   * @inheritdoc
+   */
+  public function audit(Sandbox $sandbox) {
+    $max_size = (int) $sandbox->getParameter('max_size', 2000000);
+    $extensions = (array) $sandbox->getParameter('extensions', []);
+    $sandbox->setParameter('readable_max_size', $max_size / 1000 / 1000 . ' MB');
+    $query = "SELECT fm.uri, fm.filesize, (SELECT COUNT(*) FROM file_usage fu WHERE fu.fid = fm.fid) as 'usage' FROM file_managed fm WHERE fm.filesize >= @size ORDER BY fm.filesize DESC";
+    $query = strtr($query, ['@size' => $max_size]);
+    $output = $sandbox->drush()->sqlQuery($query);
+
+    if (empty($output)) {
+      return TRUE;
+    }
+
+    $records = is_array($output) ? $output : explode("\n", $output);
+    $rows = array();
+    foreach ($records as $record) {
+      // Ignore record if it contains message about adding RSA key to known hosts.
+      if (strpos($record, '(RSA) to the list of known hosts') != FALSE) {
+        continue;
+      }
+
+      foreach ($extensions as $extension) {
+        if (strrpos($record, $extension, -strlen($extension)) === FALSE) {
+          // Create the columns
+          $parts = explode("\t", $record);
+          $rows[] = [
+            'uri' => $parts[0],
+            'size' => number_format((float)$parts[1] / 1000 / 1000, 2) . ' MB',
+            'usage' => ($parts[2] == 0) ? 'No' : 'Yes'
+          ];
+        }
+      }
+    }
+    $totalRows = count($rows);
+
+    if ($totalRows < 1) {
+      return TRUE;
+    }
+    $sandbox->setParameter('total', $totalRows);
+
+    // Reduce the number of rows to 10
+    $rows = array_slice($rows, 0, 10);
+    $too_many_files = ($totalRows > 10) ? "Only the first 10 files are displayed." : "";
+
+    $sandbox->setParameter('too_many_files', $too_many_files);
+    $sandbox->setParameter('files', $rows);
+    $sandbox->setParameter('plural', $totalRows > 1 ? 's' : '');
+
+    return Audit::FAIL;
+  }
+
+}

--- a/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
+++ b/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
@@ -95,7 +95,7 @@ class LargeDrupalFilesOfTypes extends Audit {
     $sandbox->setParameter('files', $rows);
     $sandbox->setParameter('plural', $totalRows > 1 ? 's' : '');
 
-    return Audit::FAIL;
+    return Audit::WARNING;
   }
 
 }

--- a/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
+++ b/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
@@ -70,15 +70,17 @@ class LargeDrupalFilesOfTypes extends Audit {
 
       foreach ($extensions as $extension) {
         $parts = explode("\t", $record);
-        $e = explode(".", $parts[0]);
-        if (end($e) == $extension) {
-          // Create the columns
-          $rows[] = [
-            'uri' => $parts[0],
-            'size' => $this->readableSize($parts[1]),
-            'usage' => ($parts[2] == 0) ? 'No' : 'Yes'
-          ];
-          break;
+        if ($parts[0]) {
+          $file_ext = pathinfo($parts[0], PATHINFO_EXTENSION);
+          if ($file_ext === $extension) {
+            // Create the columns
+            $rows[] = [
+              'uri' => $parts[0],
+              'size' => $this->readableSize($parts[1]),
+              'usage' => ($parts[2] == 0) ? 'No' : 'Yes'
+            ];
+            break;
+          }
         }
       }
     }

--- a/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
+++ b/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
@@ -77,6 +77,7 @@ class LargeDrupalFilesOfTypes extends Audit {
             'size' => number_format((float)$parts[1] / 1000 / 1000, 2) . ' MB',
             'usage' => ($parts[2] == 0) ? 'No' : 'Yes'
           ];
+          break;
         }
       }
     }

--- a/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
+++ b/src/Audit/Drupal/LargeDrupalFilesOfTypes.php
@@ -69,9 +69,10 @@ class LargeDrupalFilesOfTypes extends Audit {
       }
 
       foreach ($extensions as $extension) {
-        if (strrpos($record, $extension, -strlen($extension)) === FALSE) {
+        $parts = explode("\t", $record);
+        $e = explode(".", $parts[0]);
+        if (end($e) == $extension) {
           // Create the columns
-          $parts = explode("\t", $record);
           $rows[] = [
             'uri' => $parts[0],
             'size' => number_format((float)$parts[1] / 1000 / 1000, 2) . ' MB',
@@ -96,7 +97,7 @@ class LargeDrupalFilesOfTypes extends Audit {
     $sandbox->setParameter('files', $rows);
     $sandbox->setParameter('plural', $totalRows > 1 ? 's' : '');
 
-    return Audit::WARNING;
+    return Audit::WARNING_FAIL;
   }
 
 }


### PR DESCRIPTION
This adds a new audit and policy which is almost a carbon copy of the largeDrupalFiles implementation with the added parameter of having input file extensions which are checked for to target large image files which have been uploaded through typical means.

This PR will resolve #36 