### PR TITLE
Audit for MIMEMail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 sudo: false
 dist: trusty
 php:
-- '7.1'
+- '7.2'
 cache:
   bundler: true
   apt: true

--- a/Policy/d7.MimeMailModuleDisabled.policy.yml
+++ b/Policy/d7.MimeMailModuleDisabled.policy.yml
@@ -1,0 +1,23 @@
+title: MimeMail Module is not installed
+name: Drupal-7:MimeMailModuleDisabled
+class: \Drutiny\Plugin\Drupal7\Audit\ModuleDisabled
+tags:
+  - Drupal 7
+  - Best Practice
+  - Performance
+description: |
+  GovCMS strongly suggests SwiftMailer so that SMTP can be configured
+  to provide email verification. The use of MimeMail is considered to
+  be deprecated and discouraged. This audit is to provide customers
+  and Finance staff visibility into the scope of migrating any customers
+  using this module to SwiftMailer for when MimeMail is to be removed
+  from the distribution.
+remediation: |
+  Disable the mimemail module: `drush pm-uninstall mimemail -y`.
+success: The mimemail module is not currently enabled.
+failure: The mimemail module is currently enabled.
+parameters:
+  module:
+    type: string
+    description: The name of the module to ensure is not installed.
+    default: mimemail

--- a/Profiles/d7-full.profile.yml
+++ b/Profiles/d7-full.profile.yml
@@ -33,6 +33,8 @@ policies:
     severity: normal
   Drupal-7:UpdateModuleDisabled:
     severity: high
+  Drupal-7:MimeMailModuleDisabled:
+    severity: high
 
   # permissions
   Drupal-7:BlackListPermissions:


### PR DESCRIPTION
As govcms now strongly suggests the use of swiftmailer for Drupal 7 and mimemail is strongly discouraged we should audit for cases where this module is still enabled so that we can at least distinguish these sites from the others.