### PR TITLE
GOVCMS-4234: Add audit for layout builder

### DIFF
--- a/Policy/d8.LayoutBuilderModuleDisabled.policy.yml
+++ b/Policy/d8.LayoutBuilderModuleDisabled.policy.yml
@@ -11,7 +11,7 @@ description: |
   later, however as an interim solution this will show data to
   the team in the dashboard for visibility.
 remediation: |
-  Optionally sisable the layout_builder module: `drush pm-uninstall layout_builder -y`.
+  Optionally disable the layout_builder module: `drush pm-uninstall layout_builder -y`.
 success: The layout_builder module is not currently enabled.
 failure: The layout_builder module is currently enabled.
 parameters:

--- a/Policy/d8.LayoutBuilderModuleDisabled.policy.yml
+++ b/Policy/d8.LayoutBuilderModuleDisabled.policy.yml
@@ -1,6 +1,6 @@
 title: Layout Builder is not installed
 name: Drupal-8:LayoutBuilderModuleDisabled
-class: \Drutiny\Plugin\Drupal7\Audit\ModuleDisabled
+class: \Drutiny\Plugin\Drupal8\Audit\ModuleDisabled
 tags:
   - Drupal 8
   - Maintenance

--- a/Policy/d8.LayoutBuilderModuleDisabled.policy.yml
+++ b/Policy/d8.LayoutBuilderModuleDisabled.policy.yml
@@ -1,0 +1,21 @@
+title: Layout Builder is not installed
+name: Drupal-8:LayoutBuilderModuleDisabled
+class: \Drutiny\Plugin\Drupal7\Audit\ModuleDisabled
+tags:
+  - Drupal 8
+  - Maintenance
+description: |
+  For the purposes of upgrading to Drupal 8.8.x it is important
+  for the GovCMS team to be aware of any and all sites which are
+  using this module. This policy will be removed from the profile
+  later, however as an interim solution this will show data to
+  the team in the dashboard for visibility.
+remediation: |
+  Optionally sisable the layout_builder module: `drush pm-uninstall layout_builder -y`.
+success: The layout_builder module is not currently enabled.
+failure: The layout_builder module is currently enabled.
+parameters:
+  module:
+    type: string
+    description: The name of the module to ensure is not installed.
+    default: layout_builder

--- a/Profiles/d8-full.profile.yml
+++ b/Profiles/d8-full.profile.yml
@@ -18,6 +18,8 @@ policies:
     severity: normal
   Drupal-8:UpdateDisabled:
     severity: high
+  Drupal-8:LayoutBuilderModuleDisabled:
+    severity: normal
 
   # permissions
   Drupal:AnonSession:


### PR DESCRIPTION
This adds an audit which is focused on providing visibility while we upgrade to 8.8.x.

The intention is to be made aware of any individual projects utilizing the `layout_builder` module.